### PR TITLE
added missing commas in dictccSettings.json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ This Alfred workflow uses the offline translation databases provided by dict.cc.
 		"downloadedDictionaryFile": "[path to file]",
 		"languageOrderInDictionaryFile": [{
 			"identifier":"de",
-			"completeName":"German"
+			"completeName":"German",
 			"icon":"icons/icon.png"
 		},{
 			"identifier":"en",
-			"completeName":"English"
+			"completeName":"English",
 			"icon":"icons/icon.png"
 		}],
 		"supportedDirection":"both"


### PR DESCRIPTION
Just added two missing commas in the example file which prevent the workflow from running correctly.
